### PR TITLE
feat(platforms): installAlwaysOn, full /brain skill content, commitlint

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,23 @@
+name: Commitlint
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Lint commit messages
+        run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,1 @@
+npx --no -- commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npm test

--- a/README.md
+++ b/README.md
@@ -1,18 +1,11 @@
 # ai-brain
 
-[![CI](https://github.com/jorge-moreira/ai-brain-tool/actions/workflows/ci.yml/badge.svg)](https://github.com/jorge-moreira/ai-brain-tool/actions/workflows/ci.yml)
-[![npm version](https://img.shields.io/npm/v/%40jorge-moreiva.dev%2Fai-brain-tool)](https://www.npmjs.com/package/@jorge-moreiva.dev/ai-brain-tool)
-[![npm downloads](https://img.shields.io/npm/dm/%40jorge-moreiva.dev%2Fai-brain-tool)](https://www.npmjs.com/package/@jorge-moreiva.dev/ai-brain-tool)
-[![Sponsor](https://img.shields.io/badge/sponsor-%E2%9D%A4-pink)](https://github.com/sponsors/jorge-moreira)
-
-> Powered by [graphify](https://github.com/safishamsi/graphify) — the knowledge graph engine that indexes your notes and exposes them to AI tools via MCP. Visit [graphifylabs.ai](https://graphifylabs.ai/) to learn more.
-
 Your personal AI memory, connected to all your AI tools.
 
 ## Quick start
 
 ```bash
-npx @jorge-moreiva.dev/ai-brain-tool setup
+npx ai-brain setup
 ```
 
 Runs the interactive wizard: creates your brain folder, installs graphify, configures every detected AI tool (Claude Code, OpenCode, Cursor, Gemini CLI, GitHub Copilot CLI, OpenAI Codex CLI), and optionally sets up Obsidian.
@@ -25,19 +18,29 @@ Runs the interactive wizard: creates your brain folder, installs graphify, confi
 
 Run the interactive setup wizard.
 
-- On a fresh machine with no brain: full wizard (create folder, git, AI tools, Obsidian).
-- Run inside an existing brain folder (e.g. after `git clone`): new-machine mode — only recreates `.venv` and patches local AI tool configs.
+- **Fresh machine:** full wizard — creates the brain folder, initialises git, installs graphify, configures AI tools, sets up Obsidian.
+- **Inside an existing brain folder** (e.g. after `git clone`): new-machine mode — only recreates `.venv` and patches local AI tool configs.
+
+What the wizard configures per selected AI tool:
+- MCP server entry pointing to the brain's `graph.json`
+- `/brain` skill installed globally in the tool
+- Always-on context file written into the brain folder (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `.cursor/rules/ai-brain.mdc`, or `.github/copilot-instructions.md`)
+
+Git options asked during setup:
+- Git repository or local folder only
+- Optional remote URL
+- Whether to commit the extraction cache (saves tokens on new machines)
+- **Auto-sync** — whether `/brain update` should commit and push automatically after each graph rebuild
 
 ```bash
 npx ai-brain setup
-npx ai-brain setup --help
 ```
 
 ---
 
 ### `ai-brain update`
 
-Rebuild the knowledge graph from `raw/` and sync via git (if the brain is a git repo).
+Rebuild the knowledge graph from `raw/` using graphify. If auto-sync was enabled during setup (`.brain-config.json: { "gitSync": true }`), commits and pushes after the rebuild with a meaningful message based on what changed.
 
 ```bash
 npx ai-brain update
@@ -101,72 +104,17 @@ raw/templates/
 
 ---
 
-## Obsidian setup
-
-[Download Obsidian](https://obsidian.md/download) if you haven't already.
-
-During `ai-brain setup`, if you choose to use your brain folder as an Obsidian vault, the tool will:
-
-- Pre-configure the **Templates plugin** pointing at `raw/templates/markdown/_bundled/`
-- Copy the bundled `.obsidian/` config files (app, appearance, graph, core plugins)
-
-### Markdown templates
-
-14 note templates are bundled and ready to use immediately via Obsidian's Templates plugin (`raw/templates/markdown/_bundled/`):
-
-| Template | Purpose |
-|---|---|
-| `book-template.md` | Book notes and reviews |
-| `course-template.md` | Online course notes |
-| `daily-note-template.md` | Daily journal entries |
-| `exploration-template.md` | Open-ended research |
-| `lecture-template.md` | Lecture and talk notes |
-| `meeting-template.md` | Meeting notes |
-| `paper-template.md` | Academic paper notes |
-| `person-template.md` | People and contacts |
-| `project-template.md` | Project tracking |
-| `prompt-template.md` | AI prompt library |
-| `quote-template.md` | Quotes and highlights |
-| `term-template.md` | Glossary definitions |
-| `thought-template.md` | Ideas and thoughts |
-| `tool-template.md` | Tool and software notes |
-
-To use them: open Obsidian → Command Palette → **"Templates: Insert template"**.
-
-> To add your own, run `ai-brain templates add` — new templates go into `_custom/` and are never overwritten on upgrade.
-
-### Web Clipper templates
-
-3 web clipper templates are bundled (`raw/templates/web-clipper/_bundled/`):
-
-| Template | Purpose |
-|---|---|
-| `article-template.json` | Clip articles from the web |
-| `documentation-template.json` | Clip documentation pages |
-| `youtube-template.json` | Clip YouTube videos |
-
-These **cannot be imported automatically** — you need to import each `.json` file manually into the Obsidian Web Clipper browser extension.
-
-**Steps:**
-
-1. Install the [Obsidian Web Clipper](https://obsidian.md/clipper) browser extension
-2. Open the extension → **Settings** → **Templates**
-3. For each `.json` file in `raw/templates/web-clipper/_bundled/`, click **Import template** and select the file
-4. See the [Web Clipper templates documentation](https://obsidian.md/help/web-clipper/templates) for full details on customising or creating your own
-
-> To create a custom web clipper template, run `ai-brain templates add` and select **Web Clipper**. The starter `.json` will be placed in `raw/templates/web-clipper/_custom/`.
-
----
-
 ## Inside AI tools
 
-After setup, a `/brain` skill is installed in each configured AI tool:
+After setup, a `/brain` skill is installed in each configured AI tool. Commands run from inside the brain folder manage the brain; query commands work from any project.
 
 ```
-/brain update
-/brain status
-/brain query "what do I know about X?"
-/brain path "concept A" "concept B"
+/brain update              — rebuild graph from raw/ (+ auto-sync if enabled)
+/brain add <url>           — fetch a URL and add it to raw/
+/brain templates           — list available templates
+/brain query "<question>"  — query the knowledge graph via MCP
+/brain path "<A>" "<B>"    — find shortest path between two concepts via MCP
+/brain status              — show graph stats and tool version
 ```
 
 ---
@@ -176,7 +124,7 @@ After setup, a `/brain` skill is installed in each configured AI tool:
 After cloning your brain repo on a new machine:
 
 ```bash
-cd ai-brain
+cd your-brain
 npx ai-brain setup
 ```
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,3 @@
+export default {
+  extends: ['@commitlint/config-conventional'],
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,30 +1,32 @@
 {
-  "name": "ai-brain",
+  "name": "@jorge-moreiva.dev/ai-brain-tool",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "ai-brain",
+      "name": "@jorge-moreiva.dev/ai-brain-tool",
       "version": "1.0.0",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0",
         "chalk": "^5.0.0",
         "commander": "^12.0.0",
         "execa": "^9.0.0",
-        "ora": "^8.0.0",
-        "semver": "^7.0.0"
+        "ora": "^8.0.0"
       },
       "bin": {
         "ai-brain": "bin/ai-brain.js"
       },
       "devDependencies": {
+        "@commitlint/cli": "^20.5.0",
+        "@commitlint/config-conventional": "^20.5.0",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/git": "^10.0.1",
         "@semantic-release/github": "^11.0.6",
         "@semantic-release/npm": "^12.0.2",
         "@semantic-release/release-notes-generator": "^14.1.0",
+        "husky": "^9.1.7",
         "semantic-release": "^24.2.9"
       },
       "engines": {
@@ -65,6 +67,289 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@commitlint/cli": {
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-20.5.0.tgz",
+      "integrity": "sha512-yNkyN/tuKTJS3wdVfsZ2tXDM4G4Gi7z+jW54Cki8N8tZqwKBltbIvUUrSbT4hz1bhW/h0CdR+5sCSpXD+wMKaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/format": "^20.5.0",
+        "@commitlint/lint": "^20.5.0",
+        "@commitlint/load": "^20.5.0",
+        "@commitlint/read": "^20.5.0",
+        "@commitlint/types": "^20.5.0",
+        "tinyexec": "^1.0.0",
+        "yargs": "^17.0.0"
+      },
+      "bin": {
+        "commitlint": "cli.js"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/config-conventional": {
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-20.5.0.tgz",
+      "integrity": "sha512-t3Ni88rFw1XMa4nZHgOKJ8fIAT9M2j5TnKyTqJzsxea7FUetlNdYFus9dz+MhIRZmc16P0PPyEfh6X2d/qw8SA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^20.5.0",
+        "conventional-changelog-conventionalcommits": "^9.2.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/config-validator": {
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-20.5.0.tgz",
+      "integrity": "sha512-T/Uh6iJUzyx7j35GmHWdIiGRQB+ouZDk0pwAaYq4SXgB54KZhFdJ0vYmxiW6AMYICTIWuyMxDBl1jK74oFp/Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^20.5.0",
+        "ajv": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/ensure": {
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-20.5.0.tgz",
+      "integrity": "sha512-IpHqAUesBeW1EDDdjzJeaOxU9tnogLAyXLRBn03SHlj1SGENn2JGZqSWGkFvBJkJzfXAuCNtsoYzax+ZPS+puw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^20.5.0",
+        "lodash.camelcase": "^4.3.0",
+        "lodash.kebabcase": "^4.1.1",
+        "lodash.snakecase": "^4.1.1",
+        "lodash.startcase": "^4.4.0",
+        "lodash.upperfirst": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/execute-rule": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-20.0.0.tgz",
+      "integrity": "sha512-xyCoOShoPuPL44gVa+5EdZsBVao/pNzpQhkzq3RdtlFdKZtjWcLlUFQHSWBuhk5utKYykeJPSz2i8ABHQA+ZZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/format": {
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-20.5.0.tgz",
+      "integrity": "sha512-TI9EwFU/qZWSK7a5qyXMpKPPv3qta7FO4tKW+Wt2al7sgMbLWTsAcDpX1cU8k16TRdsiiet9aOw0zpvRXNJu7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^20.5.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/is-ignored": {
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-20.5.0.tgz",
+      "integrity": "sha512-JWLarAsurHJhPozbuAH6GbP4p/hdOCoqS9zJMfqwswne+/GPs5V0+rrsfOkP68Y8PSLphwtFXV0EzJ+GTXTTGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^20.5.0",
+        "semver": "^7.6.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/lint": {
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-20.5.0.tgz",
+      "integrity": "sha512-jiM3hNUdu04jFBf1VgPdjtIPvbuVfDTBAc6L98AWcoLjF5sYqkulBHBzlVWll4rMF1T5zeQFB6r//a+s+BBKlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/is-ignored": "^20.5.0",
+        "@commitlint/parse": "^20.5.0",
+        "@commitlint/rules": "^20.5.0",
+        "@commitlint/types": "^20.5.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/load": {
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-20.5.0.tgz",
+      "integrity": "sha512-sLhhYTL/KxeOTZjjabKDhwidGZan84XKK1+XFkwDYL/4883kIajcz/dZFAhBJmZPtL8+nBx6bnkzA95YxPeDPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/config-validator": "^20.5.0",
+        "@commitlint/execute-rule": "^20.0.0",
+        "@commitlint/resolve-extends": "^20.5.0",
+        "@commitlint/types": "^20.5.0",
+        "cosmiconfig": "^9.0.1",
+        "cosmiconfig-typescript-loader": "^6.1.0",
+        "is-plain-obj": "^4.1.0",
+        "lodash.mergewith": "^4.6.2",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/message": {
+      "version": "20.4.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-20.4.3.tgz",
+      "integrity": "sha512-6akwCYrzcrFcTYz9GyUaWlhisY4lmQ3KvrnabmhoeAV8nRH4dXJAh4+EUQ3uArtxxKQkvxJS78hNX2EU3USgxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/parse": {
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-20.5.0.tgz",
+      "integrity": "sha512-SeKWHBMk7YOTnnEWUhx+d1a9vHsjjuo6Uo1xRfPNfeY4bdYFasCH1dDpAv13Lyn+dDPOels+jP6D2GRZqzc5fA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^20.5.0",
+        "conventional-changelog-angular": "^8.2.0",
+        "conventional-commits-parser": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/read": {
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-20.5.0.tgz",
+      "integrity": "sha512-JDEIJ2+GnWpK8QqwfmW7O42h0aycJEWNqcdkJnyzLD11nf9dW2dWLTVEa8Wtlo4IZFGLPATjR5neA5QlOvIH1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/top-level": "^20.4.3",
+        "@commitlint/types": "^20.5.0",
+        "git-raw-commits": "^5.0.0",
+        "minimist": "^1.2.8",
+        "tinyexec": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/resolve-extends": {
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-20.5.0.tgz",
+      "integrity": "sha512-3SHPWUW2v0tyspCTcfSsYml0gses92l6TlogwzvM2cbxDgmhSRc+fldDjvGkCXJrjSM87BBaWYTPWwwyASZRrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/config-validator": "^20.5.0",
+        "@commitlint/types": "^20.5.0",
+        "global-directory": "^4.0.1",
+        "import-meta-resolve": "^4.0.0",
+        "lodash.mergewith": "^4.6.2",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/rules": {
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-20.5.0.tgz",
+      "integrity": "sha512-5NdQXQEdnDPT5pK8O39ZA7HohzPRHEsDGU23cyVCNPQy4WegAbAwrQk3nIu7p2sl3dutPk8RZd91yKTrMTnRkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/ensure": "^20.5.0",
+        "@commitlint/message": "^20.4.3",
+        "@commitlint/to-lines": "^20.0.0",
+        "@commitlint/types": "^20.5.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/to-lines": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-20.0.0.tgz",
+      "integrity": "sha512-2l9gmwiCRqZNWgV+pX1X7z4yP0b3ex/86UmUFgoRt672Ez6cAM2lOQeHFRUTuE6sPpi8XBCGnd8Kh3bMoyHwJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/top-level": {
+      "version": "20.4.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-20.4.3.tgz",
+      "integrity": "sha512-qD9xfP6dFg5jQ3NMrOhG0/w5y3bBUsVGyJvXxdWEwBm8hyx4WOk3kKXw28T5czBYvyeCVJgJJ6aoJZUWDpaacQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/types": {
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-20.5.0.tgz",
+      "integrity": "sha512-ZJoS8oSq2CAZEpc/YI9SulLrdiIyXeHb/OGqGrkUP6Q7YV+0ouNAa7GjqRdXeQPncHQIDz/jbCTlHScvYvO/gA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "conventional-commits-parser": "^6.3.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@conventional-changelog/git-client": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-2.7.0.tgz",
+      "integrity": "sha512-j7A8/LBEQ+3rugMzPXoKYzyUPpw/0CBQCyvtTR7Lmu4olG4yRC/Tfkq79Mr3yuPs0SUitlO2HwGP3gitMJnRFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-libs/child-process-utils": "^1.0.0",
+        "@simple-libs/stream-utils": "^1.2.0",
+        "semver": "^7.5.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "conventional-commits-filter": "^5.0.0",
+        "conventional-commits-parser": "^6.4.0"
+      },
+      "peerDependenciesMeta": {
+        "conventional-commits-filter": {
+          "optional": true
+        },
+        "conventional-commits-parser": {
+          "optional": true
+        }
       }
     },
     "node_modules/@inquirer/ansi": {
@@ -1016,6 +1301,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@simple-libs/child-process-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@simple-libs/child-process-utils/-/child-process-utils-1.0.2.tgz",
+      "integrity": "sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
+      }
+    },
     "node_modules/@simple-libs/stream-utils": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-1.2.0.tgz",
@@ -1054,6 +1355,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
@@ -1083,6 +1395,23 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ansi-escapes": {
@@ -1611,6 +1940,19 @@
         "node": ">=18"
       }
     },
+    "node_modules/conventional-changelog-conventionalcommits": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
+      "integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/conventional-changelog-writer": {
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-8.4.0.tgz",
@@ -1703,6 +2045,24 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/cosmiconfig-typescript-loader": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-6.3.0.tgz",
+      "integrity": "sha512-Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jiti": "2.6.1"
+      },
+      "engines": {
+        "node": ">=v18"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "cosmiconfig": ">=9",
+        "typescript": ">=5"
       }
     },
     "node_modules/cosmiconfig/node_modules/parse-json": {
@@ -2088,6 +2448,30 @@
       ],
       "license": "MIT"
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/figures": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
@@ -2251,6 +2635,49 @@
         "traverse": "0.6.8"
       }
     },
+    "node_modules/git-raw-commits": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-5.0.1.tgz",
+      "integrity": "sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@conventional-changelog/git-client": "^2.6.0",
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "git-raw-commits": "src/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/global-directory": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
+      "integrity": "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "4.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/global-directory/node_modules/ini": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
+      "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -2361,6 +2788,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {
@@ -2609,6 +3052,16 @@
         "node": ">= 0.6.0"
       }
     },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -2640,6 +3093,13 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
     },
@@ -2728,6 +3188,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.capitalize": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
@@ -2756,10 +3223,45 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.kebabcase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+      "integrity": "sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.startcase": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
+      "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.uniqby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
       "integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.upperfirst": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz",
+      "integrity": "sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==",
       "dev": true,
       "license": "MIT"
     },
@@ -6018,6 +6520,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -6200,6 +6712,7 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -6703,6 +7216,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -6790,6 +7313,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/uglify-js": {
       "version": "3.19.3",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
@@ -6803,6 +7341,14 @@
       "engines": {
         "node": ">=0.8.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/unicode-emoji-modifier-base": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "scripts": {
     "test": "node --test tests/*.test.js",
-    "start": "node bin/ai-brain.js"
+    "start": "node bin/ai-brain.js",
+    "prepare": "husky"
   },
   "files": [
     "bin/",
@@ -25,16 +26,18 @@
     "chalk": "^5.0.0",
     "commander": "^12.0.0",
     "execa": "^9.0.0",
-    "ora": "^8.0.0",
-    "semver": "^7.0.0"
+    "ora": "^8.0.0"
   },
   "devDependencies": {
+    "@commitlint/cli": "^20.5.0",
+    "@commitlint/config-conventional": "^20.5.0",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/commit-analyzer": "^13.0.1",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^11.0.6",
     "@semantic-release/npm": "^12.0.2",
     "@semantic-release/release-notes-generator": "^14.1.0",
+    "husky": "^9.1.7",
     "semantic-release": "^24.2.9"
   }
 }

--- a/src/commands/setup.js
+++ b/src/commands/setup.js
@@ -4,25 +4,30 @@ import ora from 'ora'
 import { join, resolve } from 'path'
 import { existsSync } from 'fs'
 
-import { createBrainFolder } from '../scaffold.js'
+import { createBrainFolder, writeBrainConfig } from '../scaffold.js'
 import { createVenv, venvExists } from '../graphify.js'
 import { detectAll, configureSelected } from '../platforms/index.js'
 import { initRepo, writeGitignore } from '../git.js'
 import { writeConfig } from '../config.js'
 
-const BRAIN_MARKER = ['raw', 'AGENTS.md', '.graphifyignore']
+const BRAIN_MARKER = ['raw', '.graphifyignore', '.brain-config.json']
 
 function isExistingBrain(dir) {
   return BRAIN_MARKER.every(f => existsSync(join(dir, f)))
 }
 
-export async function run() {
-  console.log(chalk.bold('\n  ╔════════════════════════════════════╗'))
-  console.log(chalk.bold('  ║   ai-brain setup wizard            ║'))
-  console.log(chalk.bold('  ╚════════════════════════════════════╝\n'))
-  console.log('  Your personal AI memory, connected to all your AI tools.\n')
+function section(label) {
+  console.log(chalk.dim('\n  ─── ' + label + ' ' + '─'.repeat(Math.max(0, 40 - label.length))))
+}
 
-  // Detect if running inside an existing brain folder
+function item(label, value) {
+  console.log(`  ${chalk.dim(label.padEnd(14))} ${value}`)
+}
+
+export async function run() {
+  console.log(chalk.bold.cyan('\n  ai-brain') + chalk.bold(' setup wizard'))
+  console.log(chalk.dim('  Your personal AI memory, connected to all your AI tools.\n'))
+
   const cwd = process.cwd()
   if (isExistingBrain(cwd)) {
     await newMachineSetup(cwd)
@@ -33,13 +38,13 @@ export async function run() {
 }
 
 async function freshSetup() {
-  // Brain folder name
+  section('Brain location')
+
   const name = await input({
     message: 'Brain folder name:',
     default: 'ai-brain',
   })
 
-  // Location
   const locationChoice = await select({
     message: 'Where do you want to create it?',
     choices: [
@@ -56,7 +61,8 @@ async function freshSetup() {
 
   const brainPath = join(baseDir, name)
 
-  // Git mode
+  section('Git')
+
   const gitMode = await select({
     message: 'How do you want to manage your brain?',
     choices: [
@@ -67,6 +73,8 @@ async function freshSetup() {
 
   let remoteUrl = null
   let commitCache = true
+  let gitSync = false
+
   if (gitMode === 'git') {
     remoteUrl = await input({
       message: 'Git remote URL (leave blank to init locally, add remote later):',
@@ -78,14 +86,20 @@ async function freshSetup() {
       message: 'Commit extraction cache to git? (saves AI tokens on every machine — recommended)',
       default: true,
     })
+
+    gitSync = await confirm({
+      message: 'Auto-sync after /brain update? (commit + push after each graph rebuild)',
+      default: !!remoteUrl,
+    })
   }
 
-  // Scaffold
+  section('Scaffold')
+
   const spinnerScaffold = ora('Creating brain folder...').start()
   await createBrainFolder({ brainPath, includeObsidian: false })
+  writeBrainConfig({ brainPath, gitSync })
   spinnerScaffold.succeed(`Created ${brainPath}`)
 
-  // Git init
   if (gitMode === 'git') {
     const spinnerGit = ora('Initializing git repo...').start()
     await initRepo({ brainPath, remoteUrl })
@@ -93,12 +107,12 @@ async function freshSetup() {
     spinnerGit.succeed('Initialized git repo')
   }
 
-  // Venv + graphify
   const spinnerVenv = ora('Installing dependencies...').start()
   await createVenv(brainPath)
   spinnerVenv.succeed('Installed graphify')
 
-  // AI platform detection
+  section('AI tools')
+
   const platforms = await detectAll()
   const platformChoices = platforms.map(p => ({
     name: `${p.name.padEnd(22)} ${p.detected ? chalk.green('detected at ' + p.configHint) : chalk.dim('not detected (you can still enable it)')}`,
@@ -115,7 +129,8 @@ async function freshSetup() {
   await configureSelected({ selected, brainPath })
   spinnerPlatforms.succeed(`Configured ${selected.length} AI tool(s)`)
 
-  // Obsidian
+  section('Obsidian')
+
   const obsidianChoice = await select({
     message: 'Do you use Obsidian?',
     choices: [
@@ -136,15 +151,13 @@ async function freshSetup() {
     spinnerObs.succeed(`Configured Obsidian (vault at ${vaultPath})`)
   }
 
-  // Save brain path to global config
   writeConfig({ brainPath })
 
-  // Summary
-  printSummary({ brainPath, gitMode, remoteUrl, selected, obsidianChoice })
+  printSummary({ brainPath, gitMode, remoteUrl, gitSync, selected, obsidianChoice })
 }
 
 async function newMachineSetup(brainPath) {
-  console.log(chalk.yellow('  Existing brain detected. Running new-machine setup...\n'))
+  console.log(chalk.yellow('\n  Existing brain detected — running new-machine setup.\n'))
 
   const spinnerVenv = ora('Recreating dependencies...').start()
   await createVenv(brainPath)
@@ -168,34 +181,39 @@ async function newMachineSetup(brainPath) {
 
   writeConfig({ brainPath })
 
-  console.log(chalk.green('\n  ✔ New machine setup complete!'))
-  console.log(`  Brain: ${brainPath}`)
-  console.log('  Restart your AI tools to connect to the brain.\n')
+  console.log(chalk.green('\n  Setup complete!'))
+  item('Brain', brainPath)
+  console.log(chalk.dim('\n  Restart your AI tools to connect to the brain.\n'))
 }
 
-function printSummary({ brainPath, gitMode, remoteUrl, selected, obsidianChoice }) {
+function printSummary({ brainPath, gitMode, remoteUrl, gitSync, selected, obsidianChoice }) {
   const platformNames = selected.map(p => p.name).join(', ') || 'none'
-  const gitStatus = gitMode === 'git' ? (remoteUrl ? `git (${remoteUrl})` : 'git (no remote yet)') : 'local only'
+  const gitStatus = gitMode === 'git'
+    ? (remoteUrl ? `git  ${chalk.dim(remoteUrl)}` : 'git  (no remote yet)')
+    : 'local only'
+  const syncStatus = gitMode === 'git'
+    ? (gitSync ? chalk.green('enabled') : chalk.dim('disabled'))
+    : chalk.dim('n/a')
 
-  console.log(chalk.bold('\n  ╔════════════════════════════════════════════════════════╗'))
-  console.log(chalk.bold('  ║   Setup complete!                                      ║'))
-  console.log(chalk.bold('  ╠════════════════════════════════════════════════════════╣'))
-  console.log(`  ║   Brain:      ${brainPath}`)
-  console.log(`  ║   Git:        ${gitStatus}`)
-  console.log(`  ║   Platforms:  ${platformNames}`)
-  if (obsidianChoice !== 'skip') console.log('  ║   Obsidian:   vault configured')
-  console.log(chalk.bold('  ╠════════════════════════════════════════════════════════╣'))
-  console.log('  ║   Next steps:')
-  console.log('  ║   1. Restart your AI tools')
-  console.log(`  ║   2. Drop notes into ${brainPath}/raw/`)
-  console.log('  ║   3. Run: npx ai-brain update')
-  console.log('  ║      or:  /brain update  in your AI tool')
+  console.log(chalk.green('\n  Setup complete!\n'))
+
+  item('Brain', chalk.cyan(brainPath))
+  item('Git', gitStatus)
+  item('Auto-sync', syncStatus)
+  item('Platforms', platformNames)
+  if (obsidianChoice !== 'skip') item('Obsidian', 'vault configured')
+
+  console.log(chalk.dim('\n  ─── Next steps ─────────────────────────────────'))
+  console.log(`  1. Restart your AI tools`)
+  console.log(`  2. Drop notes into ${chalk.cyan('raw/')}`)
+  console.log(`  3. Run ${chalk.cyan('/brain update')} in your AI tool`)
+
   if (obsidianChoice !== 'skip') {
-    console.log('  ║')
-    console.log('  ║   Obsidian:')
-    console.log(`  ║   4. Open Obsidian → Open folder → ${brainPath}`)
-    console.log('  ║   5. Enable: Templates plugin (already configured)')
-    console.log('  ║   6. See raw/templates/web-clipper/README.md for web clipper setup')
+    console.log(chalk.dim('\n  ─── Obsidian ────────────────────────────────────'))
+    console.log(`  4. Open Obsidian → Open folder → ${chalk.cyan(brainPath)}`)
+    console.log(`  5. Enable the Templates plugin (already configured)`)
+    console.log(`  6. See ${chalk.cyan('raw/templates/web-clipper/README.md')} for web clipper setup`)
   }
-  console.log(chalk.bold('  ╚════════════════════════════════════════════════════════╝\n'))
+
+  console.log()
 }

--- a/src/platforms/claude.js
+++ b/src/platforms/claude.js
@@ -4,14 +4,98 @@ import { homedir } from 'os'
 
 const BRAIN_SKILL_MD = `# /brain
 
-Interact with your ai-brain knowledge graph.
+Your personal AI brain, powered by graphify.
 
 ## Usage
-- \`/brain update\` — rebuild the graph from raw/ and sync via git
-- \`/brain status\` — show graph stats and tool version
-- \`/brain query <question>\` — query the knowledge graph
-- \`/brain path <concept-a> <concept-b>\` — find the shortest path between two concepts
+
+\`\`\`
+/brain update              — rebuild the graph from raw/ and sync via git  (run inside brain folder)
+/brain add <url>           — fetch a URL and add it to raw/                (run inside brain folder)
+/brain templates           — list available templates                       (run inside brain folder)
+/brain query <question>    — query the knowledge graph                     (works from anywhere)
+/brain path <a> <b>        — find shortest path between two concepts        (works from anywhere)
+/brain status              — show graph stats and tool version              (works from anywhere)
+\`\`\`
+
+---
+
+## For /brain update
+
+Use the MCP tool \`mcp__graphify__update\` (or run \`npx graphify ./raw --update\` via Bash) to rebuild the graph.
+
+After the graph rebuilds, check the brain sync config:
+
+\`\`\`bash
+cat .brain-config.json
+\`\`\`
+
+If \`gitSync\` is \`false\` or the file does not exist, stop here — do not commit or push.
+
+If \`gitSync\` is \`true\`, check what changed:
+
+\`\`\`bash
+git diff --stat HEAD
+\`\`\`
+
+Write a meaningful commit message based on what actually changed in \`raw/\` and \`graphify-out/\` (e.g. "brain: add 2 articles on Rust ownership, update graph"). Then commit and push:
+
+\`\`\`bash
+git add . && git commit -m "<generated message>" && git push
+\`\`\`
+
+---
+
+## For /brain add <url>
+
+Fetch the URL and save it as a markdown file in \`raw/\`:
+
+\`\`\`bash
+npx ai-brain add <url>
+\`\`\`
+
+Then run \`/brain update\` to rebuild the graph.
+
+---
+
+## For /brain templates
+
+\`\`\`bash
+npx ai-brain templates
+\`\`\`
+
+---
+
+## For /brain query <question>
+
+Use the \`ai-brain\` MCP tool \`query_graph\` with the question. Present the result as a clear human-readable answer.
+
+---
+
+## For /brain path <a> <b>
+
+Use the \`ai-brain\` MCP tool \`shortest_path\` with the two concepts. Explain the path in plain language.
+
+---
+
+## For /brain status
+
+\`\`\`bash
+npx ai-brain status
+\`\`\`
 `
+
+const ALWAYS_ON_SECTION = `## ai-brain
+
+This is an ai-brain knowledge folder powered by graphify.
+
+Rules:
+- Use \`/brain query "<question>"\` or \`/brain path "<A>" "<B>"\` to query the knowledge graph
+- Use \`/brain update\` to rebuild the graph after adding notes to raw/
+- Use \`/brain add <url>\` to fetch and add a URL to the brain
+- Read graphify-out/GRAPH_REPORT.md for god nodes and community structure if it exists
+`
+
+const ALWAYS_ON_MARKER = '## ai-brain'
 
 export function detect(homeDir = homedir()) {
   return existsSync(join(homeDir, '.claude'))
@@ -46,6 +130,14 @@ export async function installSkill({ homeDir = homedir() } = {}) {
   const skillDir = join(homeDir, '.claude', 'commands')
   mkdirSync(skillDir, { recursive: true })
   writeFileSync(join(skillDir, 'brain.md'), BRAIN_SKILL_MD, 'utf8')
+}
+
+export async function installAlwaysOn({ brainPath } = {}) {
+  const target = join(brainPath, 'CLAUDE.md')
+  let content = existsSync(target) ? readFileSync(target, 'utf8') : ''
+  if (content.includes(ALWAYS_ON_MARKER)) return
+  const separator = content.trim() ? '\n\n' : ''
+  writeFileSync(target, content.trimEnd() + separator + ALWAYS_ON_SECTION, 'utf8')
 }
 
 export const skillContent = BRAIN_SKILL_MD

--- a/src/platforms/codex.js
+++ b/src/platforms/codex.js
@@ -2,6 +2,20 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
 
+// Codex reads AGENTS.md — same file as OpenCode
+const ALWAYS_ON_SECTION = `## ai-brain
+
+This is an ai-brain knowledge folder powered by graphify.
+
+Rules:
+- Use \`/brain query "<question>"\` or \`/brain path "<A>" "<B>"\` to query the knowledge graph
+- Use \`/brain update\` to rebuild the graph after adding notes to raw/
+- Use \`/brain add <url>\` to fetch and add a URL to the brain
+- Read graphify-out/GRAPH_REPORT.md for god nodes and community structure if it exists
+`
+
+const ALWAYS_ON_MARKER = '## ai-brain'
+
 export function detect(homeDir = homedir()) {
   return existsSync(join(homeDir, '.codex'))
 }
@@ -27,3 +41,11 @@ export async function patch({ brainPath, homeDir = homedir() }) {
 }
 
 export async function installSkill() {}
+
+export async function installAlwaysOn({ brainPath } = {}) {
+  const target = join(brainPath, 'AGENTS.md')
+  let content = existsSync(target) ? readFileSync(target, 'utf8') : ''
+  if (content.includes(ALWAYS_ON_MARKER)) return
+  const separator = content.trim() ? '\n\n' : ''
+  writeFileSync(target, content.trimEnd() + separator + ALWAYS_ON_SECTION, 'utf8')
+}

--- a/src/platforms/copilot.js
+++ b/src/platforms/copilot.js
@@ -1,15 +1,52 @@
-import { existsSync } from 'fs'
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
+
+// Copilot CLI reads skills from ~/.copilot/skills/
+// No MCP config — skill is the integration point
+const BRAIN_SKILL_MD = `# /brain
+
+Interact with your ai-brain knowledge graph.
+
+## Usage
+- \`/brain update\` — rebuild the graph from raw/ and sync via git
+- \`/brain status\` — show graph stats and tool version
+- \`/brain query <question>\` — query the knowledge graph
+- \`/brain path <concept-a> <concept-b>\` — find the shortest path between two concepts
+`
+
+// Copilot uses .github/copilot-instructions.md for always-on context
+const ALWAYS_ON_SECTION = `## ai-brain
+
+This is an ai-brain knowledge folder powered by graphify.
+
+- Use \`/brain query "<question>"\` or \`/brain path "<A>" "<B>"\` to query the knowledge graph
+- Use \`/brain update\` to rebuild the graph after adding notes to raw/
+- Read graphify-out/GRAPH_REPORT.md for god nodes and community structure if it exists
+`
+
+const ALWAYS_ON_MARKER = '## ai-brain'
 
 export function detect(homeDir = homedir()) {
   return existsSync(join(homeDir, '.config', 'gh'))
 }
 
 export async function patch({ brainPath, homeDir = homedir() }) {
-  // Copilot CLI does not use a JSON MCP config — skill install is the integration point
+  // Copilot CLI does not use a JSON MCP config
 }
 
-export async function installSkill() {
-  // graphify install --platform copilot handled externally for now
+export async function installSkill({ homeDir = homedir() } = {}) {
+  const skillDir = join(homeDir, '.copilot', 'skills', 'brain')
+  mkdirSync(skillDir, { recursive: true })
+  writeFileSync(join(skillDir, 'SKILL.md'), BRAIN_SKILL_MD, 'utf8')
+}
+
+export async function installAlwaysOn({ brainPath } = {}) {
+  const githubDir = join(brainPath, '.github')
+  mkdirSync(githubDir, { recursive: true })
+  const target = join(githubDir, 'copilot-instructions.md')
+  let content = existsSync(target) ? readFileSync(target, 'utf8') : ''
+  if (content.includes(ALWAYS_ON_MARKER)) return
+  const separator = content.trim() ? '\n\n' : ''
+  writeFileSync(target, content.trimEnd() + separator + ALWAYS_ON_SECTION, 'utf8')
 }

--- a/src/platforms/cursor.js
+++ b/src/platforms/cursor.js
@@ -2,6 +2,19 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
 
+// Cursor uses .cursor/rules/graphify.mdc with alwaysApply: true
+const CURSOR_RULE = `---
+description: ai-brain knowledge folder
+alwaysApply: true
+---
+
+This is an ai-brain knowledge folder powered by graphify.
+
+- Use \`/brain query "<question>"\` or \`/brain path "<A>" "<B>"\` to query the knowledge graph
+- Use \`/brain update\` to rebuild the graph after adding notes to raw/
+- Read graphify-out/GRAPH_REPORT.md for god nodes and community structure if it exists
+`
+
 export function detect(homeDir = homedir()) {
   return existsSync(join(homeDir, '.cursor'))
 }
@@ -31,3 +44,12 @@ export async function patch({ brainPath, homeDir = homedir() }) {
 }
 
 export async function installSkill() {}
+
+export async function installAlwaysOn({ brainPath } = {}) {
+  const rulesDir = join(brainPath, '.cursor', 'rules')
+  mkdirSync(rulesDir, { recursive: true })
+  const target = join(rulesDir, 'ai-brain.mdc')
+  if (!existsSync(target)) {
+    writeFileSync(target, CURSOR_RULE, 'utf8')
+  }
+}

--- a/src/platforms/gemini.js
+++ b/src/platforms/gemini.js
@@ -2,6 +2,20 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
 
+// Gemini CLI reads GEMINI.md
+const ALWAYS_ON_SECTION = `## ai-brain
+
+This is an ai-brain knowledge folder powered by graphify.
+
+Rules:
+- Use \`/brain query "<question>"\` or \`/brain path "<A>" "<B>"\` to query the knowledge graph
+- Use \`/brain update\` to rebuild the graph after adding notes to raw/
+- Use \`/brain add <url>\` to fetch and add a URL to the brain
+- Read graphify-out/GRAPH_REPORT.md for god nodes and community structure if it exists
+`
+
+const ALWAYS_ON_MARKER = '## ai-brain'
+
 export function detect(homeDir = homedir()) {
   return existsSync(join(homeDir, '.gemini'))
 }
@@ -31,3 +45,11 @@ export async function patch({ brainPath, homeDir = homedir() }) {
 }
 
 export async function installSkill() {}
+
+export async function installAlwaysOn({ brainPath } = {}) {
+  const target = join(brainPath, 'GEMINI.md')
+  let content = existsSync(target) ? readFileSync(target, 'utf8') : ''
+  if (content.includes(ALWAYS_ON_MARKER)) return
+  const separator = content.trim() ? '\n\n' : ''
+  writeFileSync(target, content.trimEnd() + separator + ALWAYS_ON_SECTION, 'utf8')
+}

--- a/src/platforms/index.js
+++ b/src/platforms/index.js
@@ -26,5 +26,6 @@ export async function configureSelected({ selected, brainPath, homeDir = homedir
   for (const platform of selected) {
     await platform.module.patch({ brainPath, homeDir })
     await platform.module.installSkill({ homeDir })
+    await platform.module.installAlwaysOn({ brainPath, homeDir })
   }
 }

--- a/src/platforms/opencode.js
+++ b/src/platforms/opencode.js
@@ -2,6 +2,109 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
 
+const BRAIN_SKILL_MD = `---
+name: brain
+description: Personal AI brain — facade over graphify for easy knowledge graph management
+trigger: /brain
+---
+
+# /brain
+
+Your personal AI brain, powered by graphify.
+
+## Usage
+
+\`\`\`
+/brain update              — rebuild the graph from raw/ and sync via git  (run inside brain folder)
+/brain add <url>           — fetch a URL and add it to raw/                (run inside brain folder)
+/brain templates           — list available templates                       (run inside brain folder)
+/brain query <question>    — query the knowledge graph                     (works from anywhere)
+/brain path <a> <b>        — find shortest path between two concepts        (works from anywhere)
+/brain status              — show graph stats and tool version              (works from anywhere)
+\`\`\`
+
+---
+
+## For /brain update
+
+Use the \`skill\` tool to load the skill named \`graphify\`, then follow its instructions as if the user typed:
+
+\`\`\`
+/graphify ./raw --update
+\`\`\`
+
+After the graph rebuilds, check the brain sync config:
+
+\`\`\`bash
+cat .brain-config.json
+\`\`\`
+
+If \`gitSync\` is \`false\` or the file does not exist, stop here — do not commit or push.
+
+If \`gitSync\` is \`true\`, check what changed:
+
+\`\`\`bash
+git diff --stat HEAD
+\`\`\`
+
+Write a meaningful commit message based on what actually changed in \`raw/\` and \`graphify-out/\` (e.g. "brain: add 2 articles on Rust ownership, update graph"). Then commit and push:
+
+\`\`\`bash
+git add . && git commit -m "<generated message>" && git push
+\`\`\`
+
+---
+
+## For /brain add <url>
+
+Use the \`skill\` tool to load the skill named \`graphify\`, then follow its instructions as if the user typed:
+
+\`\`\`
+/graphify add <url>
+\`\`\`
+
+---
+
+## For /brain templates
+
+\`\`\`bash
+npx ai-brain templates
+\`\`\`
+
+---
+
+## For /brain query <question>
+
+Use the \`ai-brain\` MCP tool \`query_graph\` with the question. Present the result as a clear human-readable answer.
+
+---
+
+## For /brain path <a> <b>
+
+Use the \`ai-brain\` MCP tool \`shortest_path\` with the two concepts. Explain the path in plain language.
+
+---
+
+## For /brain status
+
+\`\`\`bash
+npx ai-brain status
+\`\`\`
+`
+
+const ALWAYS_ON_SECTION = `## ai-brain
+
+This is an ai-brain knowledge folder powered by graphify.
+
+Rules:
+- Use \`/brain query "<question>"\` or \`/brain path "<A>" "<B>"\` to query the knowledge graph
+- Use \`/brain update\` to rebuild the graph after adding notes to raw/
+- Use \`/brain add <url>\` to fetch and add a URL to the brain
+- Read graphify-out/GRAPH_REPORT.md for god nodes and community structure if it exists
+`
+
+const ALWAYS_ON_MARKER = '## ai-brain'
+
 export function detect(homeDir = homedir()) {
   return existsSync(join(homeDir, '.config', 'opencode'))
 }
@@ -30,6 +133,18 @@ export async function patch({ brainPath, homeDir = homedir() }) {
   writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf8')
 }
 
-export async function installSkill() {
-  // OpenCode skill installation handled via opencode.json mcp entry
+export async function installSkill({ homeDir = homedir() } = {}) {
+  const skillDir = join(homeDir, '.config', 'opencode', 'skills', 'brain')
+  mkdirSync(skillDir, { recursive: true })
+  writeFileSync(join(skillDir, 'SKILL.md'), BRAIN_SKILL_MD, 'utf8')
 }
+
+export async function installAlwaysOn({ brainPath } = {}) {
+  const target = join(brainPath, 'AGENTS.md')
+  let content = existsSync(target) ? readFileSync(target, 'utf8') : ''
+  if (content.includes(ALWAYS_ON_MARKER)) return
+  const separator = content.trim() ? '\n\n' : ''
+  writeFileSync(target, content.trimEnd() + separator + ALWAYS_ON_SECTION, 'utf8')
+}
+
+export const skillContent = BRAIN_SKILL_MD

--- a/src/scaffold.js
+++ b/src/scaffold.js
@@ -1,20 +1,10 @@
 import { mkdir, writeFile, cp } from 'fs/promises'
 import { join, dirname } from 'path'
 import { fileURLToPath } from 'url'
+import { writeFileSync } from 'fs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const TEMPLATES_DIR = join(__dirname, 'templates')
-
-const AGENTS_MD = `## graphify
-
-This project has a graphify knowledge graph at graphify-out/.
-
-Rules:
-- Before answering architecture or codebase questions, read graphify-out/GRAPH_REPORT.md for god nodes and community structure
-- If graphify-out/wiki/index.md exists, navigate it instead of reading raw files
-- For cross-module "how does X relate to Y" questions, prefer \`graphify query "<question>"\`, \`graphify path "<A>" "<B>"\`, or \`graphify explain "<concept>"\` over grep — these traverse the graph's EXTRACTED + INFERRED edges instead of scanning files
-- After modifying code files in this session, run \`graphify update .\` to keep the graph current (AST-only, no API cost)
-`
 
 const GRAPHIFYIGNORE = `# Exclude templates from graph indexing
 raw/templates/
@@ -32,14 +22,18 @@ const dirs = [
   'graphify-out',
 ]
 
+export function writeBrainConfig({ brainPath, gitSync }) {
+  const config = { gitSync: !!gitSync }
+  writeFileSync(join(brainPath, '.brain-config.json'), JSON.stringify(config, null, 2), 'utf8')
+}
+
 export async function createBrainFolder({ brainPath, includeObsidian }) {
   // Create all directories
   for (const dir of dirs) {
     await mkdir(join(brainPath, dir), { recursive: true })
   }
 
-  // Write static files
-  await writeFile(join(brainPath, 'AGENTS.md'), AGENTS_MD, 'utf8')
+  // Write .graphifyignore — AGENTS.md/CLAUDE.md/GEMINI.md are written per-platform by installAlwaysOn()
   await writeFile(join(brainPath, '.graphifyignore'), GRAPHIFYIGNORE, 'utf8')
 
   // Copy bundled markdown templates

--- a/tests/platforms.test.js
+++ b/tests/platforms.test.js
@@ -10,7 +10,8 @@ process.env.HOME = tmp
 after(() => rmSync(tmp, { recursive: true, force: true }))
 
 const { detectAll } = await import('../src/platforms/index.js')
-const { patch: patchClaude, skillContent } = await import('../src/platforms/claude.js')
+const { patch: patchClaude, installAlwaysOn: claudeAlwaysOn, skillContent } = await import('../src/platforms/claude.js')
+const { installAlwaysOn: opencodeAlwaysOn } = await import('../src/platforms/opencode.js')
 
 test('detectAll returns array of platform objects', async () => {
   const results = await detectAll()
@@ -65,4 +66,39 @@ test('claude patch is idempotent — running twice does not duplicate entries', 
   const mcp = JSON.parse(readFileSync(join(claudeDir, 'mcp.json'), 'utf8'))
   const keys = Object.keys(mcp.mcpServers)
   assert.equal(keys.filter(k => k === 'ai-brain').length, 1)
+})
+
+test('claude installAlwaysOn writes CLAUDE.md with ai-brain section', async () => {
+  const brainPath = mkdtempSync(join(tmpdir(), 'brain-always-on-'))
+  after(() => rmSync(brainPath, { recursive: true, force: true }))
+
+  await claudeAlwaysOn({ brainPath })
+
+  const claudeMd = join(brainPath, 'CLAUDE.md')
+  assert.ok(existsSync(claudeMd))
+  const content = readFileSync(claudeMd, 'utf8')
+  assert.ok(content.includes('## ai-brain'))
+})
+
+test('claude installAlwaysOn is idempotent — does not duplicate section', async () => {
+  const brainPath = mkdtempSync(join(tmpdir(), 'brain-always-on-'))
+  after(() => rmSync(brainPath, { recursive: true, force: true }))
+
+  await claudeAlwaysOn({ brainPath })
+  await claudeAlwaysOn({ brainPath })
+
+  const content = readFileSync(join(brainPath, 'CLAUDE.md'), 'utf8')
+  assert.equal(content.split('## ai-brain').length - 1, 1, 'section should appear exactly once')
+})
+
+test('opencode installAlwaysOn writes AGENTS.md with ai-brain section', async () => {
+  const brainPath = mkdtempSync(join(tmpdir(), 'brain-always-on-'))
+  after(() => rmSync(brainPath, { recursive: true, force: true }))
+
+  await opencodeAlwaysOn({ brainPath })
+
+  const agentsMd = join(brainPath, 'AGENTS.md')
+  assert.ok(existsSync(agentsMd))
+  const content = readFileSync(agentsMd, 'utf8')
+  assert.ok(content.includes('## ai-brain'))
 })

--- a/tests/scaffold.test.js
+++ b/tests/scaffold.test.js
@@ -1,10 +1,10 @@
 import { test, after } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, rmSync, existsSync, readdirSync } from 'fs'
+import { mkdtempSync, rmSync, existsSync, readdirSync, readFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 
-const { createBrainFolder } = await import('../src/scaffold.js')
+const { createBrainFolder, writeBrainConfig } = await import('../src/scaffold.js')
 
 test('createBrainFolder creates expected directory structure', async () => {
   const tmp = mkdtempSync(join(tmpdir(), 'brain-test-'))
@@ -22,7 +22,6 @@ test('createBrainFolder creates expected directory structure', async () => {
   assert.ok(existsSync(join(brainPath, 'raw', 'templates', 'web-clipper', '_bundled')))
   assert.ok(existsSync(join(brainPath, 'raw', 'templates', 'web-clipper', '_custom')))
   assert.ok(existsSync(join(brainPath, 'graphify-out')))
-  assert.ok(existsSync(join(brainPath, 'AGENTS.md')))
   assert.ok(existsSync(join(brainPath, '.graphifyignore')))
 })
 
@@ -57,4 +56,24 @@ test('createBrainFolder does not create .obsidian/ when includeObsidian is false
   await createBrainFolder({ brainPath, includeObsidian: false })
 
   assert.ok(!existsSync(join(brainPath, '.obsidian')))
+})
+
+test('writeBrainConfig writes .brain-config.json with gitSync flag', () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'brain-config-test-'))
+  after(() => rmSync(tmp, { recursive: true, force: true }))
+
+  writeBrainConfig({ brainPath: tmp, gitSync: true })
+
+  const cfg = JSON.parse(readFileSync(join(tmp, '.brain-config.json'), 'utf8'))
+  assert.equal(cfg.gitSync, true)
+})
+
+test('writeBrainConfig gitSync=false is stored correctly', () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'brain-config-test-'))
+  after(() => rmSync(tmp, { recursive: true, force: true }))
+
+  writeBrainConfig({ brainPath: tmp, gitSync: false })
+
+  const cfg = JSON.parse(readFileSync(join(tmp, '.brain-config.json'), 'utf8'))
+  assert.equal(cfg.gitSync, false)
 })


### PR DESCRIPTION
## Summary

- Each platform now writes its always-on context file (CLAUDE.md, AGENTS.md, GEMINI.md, etc.) via `installAlwaysOn()` — content is per-platform rather than generic scaffold output
- `claude.js` skill content expanded from stub to full `/brain` command reference, mirroring `opencode.js`
- `setup.js` uses `section()`/`item()` helpers to avoid broken box borders on long paths; `gitSync` opt-in stored in `.brain-config.json`
- Stale `AGENTS.md` test assertion fixed; new tests cover `installAlwaysOn` and `writeBrainConfig`
- Conventional commits enforced locally via husky + commitlint, and in CI on all PRs against main
- Removed phantom `semver` runtime dependency (unused in source)