### PR TITLE
feat: opt-in graphify extras (office, video) and Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,13 +3,13 @@ updates:
   - package-ecosystem: pip
     directory: /
     schedule:
-      interval: weekly
+      interval: daily
     labels:
       - dependencies
 
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: weekly
+      interval: daily
     labels:
       - dependencies

--- a/README.md
+++ b/README.md
@@ -165,4 +165,4 @@ The tool detects the existing brain, skips scaffolding, and only recreates `.ven
 
 ## Credits
 
-ai-brain is a facade over **[graphify](https://github.com/safishamsi/graphify)** by [@safishamsi](https://github.com/safishamsi). All graph extraction, clustering, wiki generation, Obsidian export, and MCP serving is done by graphify. This tool adds the setup wizard, platform integrations, and `/brain` skill layer on top.
+ai-brain-tool is a facade over **[graphify](https://github.com/safishamsi/graphify)** by [@safishamsi](https://github.com/safishamsi). All graph extraction, clustering, wiki generation, Obsidian export, and MCP serving is done by graphify. This tool adds the setup wizard, platform integrations, and `/brain` skill layer on top.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+graphifyy[mcp]==0.4.29

--- a/src/commands/setup.js
+++ b/src/commands/setup.js
@@ -2,7 +2,7 @@ import { input, select, checkbox, confirm } from '@inquirer/prompts'
 import chalk from 'chalk'
 import ora from 'ora'
 import { join, resolve } from 'path'
-import { existsSync } from 'fs'
+import { existsSync, readFileSync } from 'fs'
 
 import { createBrainFolder, writeBrainConfig, writeBrainPackageJson } from '../scaffold.js'
 import { createVenv, venvExists } from '../graphify.js'
@@ -94,11 +94,21 @@ async function freshSetup() {
     })
   }
 
+  section('Graphify extras')
+
+  const extras = await checkbox({
+    message: 'Which file types do you want graphify to process? (mcp is always included)',
+    choices: [
+      { name: 'Office documents  — Word, Excel (.docx, .xlsx)', value: 'office' },
+      { name: 'Video / Audio     — mp4, mp3, YouTube URLs (requires faster-whisper + yt-dlp)', value: 'video' },
+    ],
+  })
+
   section('Scaffold')
 
   const spinnerScaffold = ora('Creating brain folder...').start()
   await createBrainFolder({ brainPath, includeObsidian: false })
-  writeBrainConfig({ brainPath, gitSync })
+  writeBrainConfig({ brainPath, gitSync, extras })
   writeBrainPackageJson({ brainPath })
   spinnerScaffold.succeed(`Created ${brainPath}`)
 
@@ -113,9 +123,9 @@ async function freshSetup() {
     spinnerGit.succeed('Initialized git repo')
   }
 
-  const spinnerVenv = ora('Installing dependencies...').start()
-  await createVenv(brainPath)
-  spinnerVenv.succeed('Installed graphify')
+  const spinnerVenv = ora('Installing graphify...').start()
+  await createVenv(brainPath, extras)
+  spinnerVenv.succeed(`Installed graphify${extras.length ? ` [${extras.join(', ')}]` : ''}`)
 
   section('AI tools')
 
@@ -159,7 +169,7 @@ async function freshSetup() {
 
   writeConfig({ brainPath })
 
-  printSummary({ brainPath, gitMode, remoteUrl, gitSync, selected, obsidianChoice })
+  printSummary({ brainPath, gitMode, remoteUrl, gitSync, extras, selected, obsidianChoice })
 }
 
 async function newMachineSetup(brainPath) {
@@ -169,9 +179,16 @@ async function newMachineSetup(brainPath) {
   await execa('npm', ['install', '--prefer-offline'], { cwd: brainPath })
   spinnerNpm.succeed('Tool installed locally')
 
+  // Read extras from existing config so the same extras are reinstalled
+  let extras = []
+  try {
+    const cfg = JSON.parse(readFileSync(join(brainPath, '.brain-config.json'), 'utf8'))
+    extras = cfg.extras ?? []
+  } catch { /* ignore — use defaults */ }
+
   const spinnerVenv = ora('Recreating Python environment...').start()
-  await createVenv(brainPath)
-  spinnerVenv.succeed('Installed graphify')
+  await createVenv(brainPath, extras)
+  spinnerVenv.succeed(`Installed graphify${extras.length ? ` [${extras.join(', ')}]` : ''}`)
 
   const platforms = await detectAll()
   const platformChoices = platforms.map(p => ({
@@ -196,7 +213,7 @@ async function newMachineSetup(brainPath) {
   console.log(chalk.dim('\n  Restart your AI tools to connect to the brain.\n'))
 }
 
-function printSummary({ brainPath, gitMode, remoteUrl, gitSync, selected, obsidianChoice }) {
+function printSummary({ brainPath, gitMode, remoteUrl, gitSync, extras, selected, obsidianChoice }) {
   const platformNames = selected.map(p => p.name).join(', ') || 'none'
   const gitStatus = gitMode === 'git'
     ? (remoteUrl ? `git  ${chalk.dim(remoteUrl)}` : 'git  (no remote yet)')
@@ -210,6 +227,7 @@ function printSummary({ brainPath, gitMode, remoteUrl, gitSync, selected, obsidi
   item('Brain', chalk.cyan(brainPath))
   item('Git', gitStatus)
   item('Auto-sync', syncStatus)
+  item('Graphify', extras.length ? `mcp, ${extras.join(', ')}` : 'mcp')
   item('Platforms', platformNames)
   if (obsidianChoice !== 'skip') item('Obsidian', 'vault configured')
 

--- a/src/commands/upgrade.js
+++ b/src/commands/upgrade.js
@@ -1,6 +1,6 @@
 import chalk from 'chalk'
 import ora from 'ora'
-import { cpSync } from 'fs'
+import { cpSync, readFileSync, existsSync } from 'fs'
 import { join, dirname } from 'path'
 import { fileURLToPath } from 'url'
 import { readConfig } from '../config.js'
@@ -17,9 +17,16 @@ export async function run() {
   }
   const { brainPath } = config
 
+  // Read extras from brain config so upgrade preserves the installed extras
+  let extras = []
+  try {
+    const brainCfg = JSON.parse(readFileSync(join(brainPath, '.brain-config.json'), 'utf8'))
+    extras = brainCfg.extras ?? []
+  } catch { /* ignore — use defaults */ }
+
   const spinnerVenv = ora('Upgrading graphify...').start()
-  await upgradeVenv(brainPath)
-  spinnerVenv.succeed('Graphify upgraded')
+  await upgradeVenv(brainPath, extras)
+  spinnerVenv.succeed(`Graphify upgraded${extras.length ? ` [${extras.join(', ')}]` : ''}`)
 
   const spinnerTmpl = ora('Refreshing bundled templates...').start()
 

--- a/src/graphify.js
+++ b/src/graphify.js
@@ -1,7 +1,20 @@
 import { execa } from 'execa'
-import { existsSync } from 'fs'
-import { join } from 'path'
+import { existsSync, readFileSync } from 'fs'
+import { join, dirname } from 'path'
 import { platform } from 'process'
+import { fileURLToPath } from 'url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+// Pinned version read from requirements.txt — single source of truth for Dependabot
+const REQUIREMENTS = readFileSync(join(__dirname, '..', 'requirements.txt'), 'utf8')
+const GRAPHIFYY_VERSION = REQUIREMENTS.match(/graphifyy\[mcp\]==(.+)/)[1].trim()
+
+// Build the pip package specifier from a list of extras (always includes mcp)
+function buildPkg(extras = []) {
+  const all = ['mcp', ...extras.filter(e => e !== 'mcp')]
+  return `graphifyy[${all.join(',')}]==${GRAPHIFYY_VERSION}`
+}
 
 // Returns path to the venv Python executable
 export function venvPythonPath(brainPath) {
@@ -43,12 +56,9 @@ export async function detectPackageManager() {
   }
 }
 
-// Pinned version installed on setup — bump this when a new release is vetted
-const GRAPHIFYY_VERSION = '0.4.29'
-
-// Create .venv and install graphify[mcp]
-export async function createVenv(brainPath) {
-  const pkg = `graphifyy[mcp]==${GRAPHIFYY_VERSION}`
+// Create .venv and install graphifyy with requested extras (always includes mcp)
+export async function createVenv(brainPath, extras = []) {
+  const pkg = buildPkg(extras)
   const pm = await detectPackageManager()
   if (pm === 'uv') {
     await execa('uv', ['venv', join(brainPath, '.venv')], { stdio: 'inherit' })
@@ -61,13 +71,14 @@ export async function createVenv(brainPath) {
   }
 }
 
-// Upgrade graphify[mcp] in existing .venv
-export async function upgradeVenv(brainPath) {
+// Upgrade graphifyy in existing .venv, preserving the configured extras
+export async function upgradeVenv(brainPath, extras = []) {
+  const pkg = buildPkg(extras)
   const pm = await detectPackageManager()
   if (pm === 'uv') {
-    await execa('uv', ['pip', 'install', '--upgrade', 'graphifyy[mcp]', '--python', venvPythonPath(brainPath)], { stdio: 'inherit' })
+    await execa('uv', ['pip', 'install', '--upgrade', pkg, '--python', venvPythonPath(brainPath)], { stdio: 'inherit' })
   } else {
-    await execa(venvPythonPath(brainPath), ['-m', 'pip', 'install', '--upgrade', 'graphifyy[mcp]'], { stdio: 'inherit' })
+    await execa(venvPythonPath(brainPath), ['-m', 'pip', 'install', '--upgrade', pkg], { stdio: 'inherit' })
   }
 }
 

--- a/src/scaffold.js
+++ b/src/scaffold.js
@@ -23,8 +23,8 @@ const dirs = [
   'graphify-out',
 ]
 
-export function writeBrainConfig({ brainPath, gitSync }) {
-  const config = { gitSync: !!gitSync }
+export function writeBrainConfig({ brainPath, gitSync, extras = [] }) {
+  const config = { gitSync: !!gitSync, extras }
   writeFileSync(join(brainPath, '.brain-config.json'), JSON.stringify(config, null, 2), 'utf8')
 }
 


### PR DESCRIPTION
## Summary

- Setup wizard asks which file types to process beyond the default — **Office** (.docx, .xlsx) and **Video/Audio** (mp4, mp3, YouTube URLs). mcp is always included.
- Chosen extras stored in `.brain-config.json` and used on every `createVenv` / `upgradeVenv` call — new-machine setup and upgrade read from config automatically
- `requirements.txt` is now the single source of truth for the `graphifyy` pinned version — `graphify.js` reads it at runtime instead of a hardcoded constant
- `.github/dependabot.yml` tracks `graphifyy` on PyPI and npm dependencies weekly — Dependabot PRs will bump `requirements.txt` when new graphifyy versions are released